### PR TITLE
INREL-6111 implement non amp tipser handling

### DIFF
--- a/js/tipser.js
+++ b/js/tipser.js
@@ -11,9 +11,11 @@ const TipserProductView = Backbone.View.extend({
     click: 'handleClick'
   },
   handleClick: function(e) {
+    e.stopPropagation();
     const productId = e.currentTarget.getAttribute('data-product-id');
     this.model.set('productId', productId);
     this.openProductDialog(productId);
+    return false;
   }
 });
 

--- a/js/tipser.js
+++ b/js/tipser.js
@@ -11,7 +11,7 @@ const TipserProductView = Backbone.View.extend({
     click: 'handleClick'
   },
   handleClick: function(e) {
-    e.stopPropagation();
+    e.preventDefault();
     const productId = e.currentTarget.getAttribute('data-product-id');
     this.model.set('productId', productId);
     this.openProductDialog(productId);

--- a/js/tipser.js
+++ b/js/tipser.js
@@ -11,8 +11,8 @@ const TipserProductView = Backbone.View.extend({
     click: 'handleClick'
   },
   handleClick: function(e) {
-    e.preventDefault();
     const productId = e.currentTarget.getAttribute('data-product-id');
+    e.preventDefault();
     this.model.set('productId', productId);
     this.openProductDialog(productId);
     return false;


### PR DESCRIPTION
[INREL-6165](https://jira.burda.com/browse/INREL-6165)

It's done, when

Layout of products db paragraph is the same like e-commerce paragraph
for AMP
for non-AMP
Tech-Spec.:
Adapt "get products" endpoint for non AMP
Find solution for tipser URLs
Find solution for subid tracking for tracdelight
Image styles must reference an absolute URL
strike through price is not shown in AMP (only for this story, we need a solution for this in the future)
Sold out products should be considered in the next sprint

## Checklist:

- [x] I have verified that the code works
- [x] I have verified that the code is easy to understand
  - [ ] If not, I have left a well-balanced amount of inline comments
- [ ] I have [left the code in a better state](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule)
- [ ] I have documented the changes (where applicable)
